### PR TITLE
add yanglint as another validator

### DIFF
--- a/bottle-yang-extractor-validator/main.py
+++ b/bottle-yang-extractor-validator/main.py
@@ -117,7 +117,7 @@ def validate_yangfile(infilename, workdir):
 
 
 	yresfp = open(yanglint_resfile, 'w+')
-	status = call([yanglint_cmd, '-p', workdir, '-f', 'tree', '-V', infile], stderr = yresfp)
+	status = call([yanglint_cmd, '-p', workdir, '-p', yang_import_dir, '-V', infile], stderr = yresfp)
 
 	yresfp.seek(0)
 

--- a/bottle-yang-extractor-validator/views/main.tpl
+++ b/bottle-yang-extractor-validator/views/main.tpl
@@ -28,11 +28,13 @@
                 '<h3>XYM Extraction</h3><pre class="xymstderr"/>' +
                 '<h3>Pyang Validation</h3><pre class="pyangstderr"/>' +
                 '<h3>Pyang Output</h3><pre class="pyangoutput"/>' +
-                '<h3>Confdc Output</h3><pre class="confdcstderr"/>');
+                '<h3>Confdc Output</h3><pre class="confdcstderr"/>' +
+                '<h3>yanglint Validation</h3><pre class="yanglintstderr"/>' +
             $( '#' + sanitized + ' > pre.xymstderr' ).append(data[key].xym_stderr.length > 0 ? data[key].xym_stderr : "No warnings or errors");
             $( '#' + sanitized + ' > pre.pyangstderr' ).append(data[key].pyang_stderr.length > 0 ? data[key].pyang_stderr : "No warnings or errors");
             $( '#' + sanitized + ' > pre.pyangoutput' ).append(data[key].pyang_output.length > 0 ? data[key].pyang_output : "No output");
             $( '#' + sanitized + ' > pre.confdcstderr' ).append(data[key].confdc_stderr.length > 0 ? data[key].confdc_stderr : "No warnings or errors");
+            $( '#' + sanitized + ' > pre.yanglintstderr' ).append(data[key].yanglint_stderr.length > 0 ? data[key].yanglint_stderr : "No warnings or errors");
           }
         });
         return(false);
@@ -59,11 +61,13 @@
                 '<h3>XYM Extraction</h3><pre class="xymstderr"/>' +
                 '<h3>Pyang Validation</h3><pre class="pyangstderr"/>' +
                 '<h3>Pyang Output</h3><pre class="pyangoutput"/>' +
-                '<h3>Confdc Output</h3><pre class="confdcstderr"/>');
+                '<h3>Confdc Output</h3><pre class="confdcstderr"/>' +
+                '<h3>yanglint Validation</h3><pre class="yanglintstderr"/>');
             $( '#' + sanitized + ' > pre.xymstderr' ).append(data[key].xym_stderr.length > 0 ? data[key].xym_stderr : "No warnings or errors");
             $( '#' + sanitized + ' > pre.pyangstderr' ).append(data[key].pyang_stderr.length > 0 ? data[key].pyang_stderr : "No warnings or errors");
             $( '#' + sanitized + ' > pre.pyangoutput' ).append(data[key].pyang_output.length > 0 ? data[key].pyang_output : "No output");
-            $( '#' + sanitized + ' > pre.confdcstderr' ).append(data[key].confdc_stderr.length > 0 ? data[key].confdc_stderr : "No output");          }
+            $( '#' + sanitized + ' > pre.confdcstderr' ).append(data[key].confdc_stderr.length > 0 ? data[key].confdc_stderr : "No output");
+            $( '#' + sanitized + ' > pre.yanglintstderr' ).append(data[key].yanglint_stderr.length > 0 ? data[key].yanglint_stderr : "No warnings or errors"); }
         });
         return(false);
       }); 
@@ -150,10 +154,12 @@
         <pre class="output">{{!content["pyang_output"] if len(content["pyang_output"]) != 0 else "No warnings or errors"}}</pre>
         <h3>Confdc Output</h3>
         <pre class="output">{{!content["confdc_stderr"] if len(content["confdc_stderr"]) != 0 else "No warnings or errors"}}</pre>
+        <h3>yanglint Validation</h3>
+        <pre class="stderr">{{!content["yanglint_stderr"] if len(content["yanglint_stderr"]) != 0 else "No warnings or errors"}}</pre>
       </div>
     % end 
   % end
-    <small class="text-muted">validator version: {{versions["validator_version"]}}, xym version: {{versions["xym_version"]}}, pyang version: {{versions["pyang_version"]}} confdc version: {{versions["confdc_version"]}}</small>
+    <small class="text-muted">validator version: {{versions["validator_version"]}}, xym version: {{versions["xym_version"]}}, pyang version: {{versions["pyang_version"]}} confdc version: {{versions["confdc_version"]}}, yanglint version: {{versions["yanglint_version"]}}</small>
   </div>
 </body>
 

--- a/bottle-yang-extractor-validator/views/rest.tpl
+++ b/bottle-yang-extractor-validator/views/rest.tpl
@@ -29,6 +29,7 @@
         <li>A <code>pyang_stderr</code> object with the output of the pyang validation step</li>
         <li>A <code>pyang_output</code> object with the output of the pyang tree rendering step</li>
         <li>A <code>confdc_stderr</code> object with the output of the confdc compiler step</li>
+        <li>A <code>yanglint_stderr</code> object with the output of the yanglint validation step</li>
       </ul>
     </p>
     <dl>


### PR DESCRIPTION
Since `yanglint` supports only one searchpath, it ignores schemas in `yang_import_dir` (`/opt/local/share/yang`) - how big problem is it?